### PR TITLE
Change Dispatcher namespace in TransactionCommitWorker for testing purposes

### DIFF
--- a/src/TransactionCommitWorker.php
+++ b/src/TransactionCommitWorker.php
@@ -20,7 +20,7 @@
 namespace Jlorente\Laravel\Queue\TransactionCommit;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 
 /**


### PR DESCRIPTION
Simplifies the way to test that an event is dispatched

Event::fake();
config(['transaction-commit-queue.dispatch_instantly' => true]);
...
Event::assertDispatched(UserCreated::class);